### PR TITLE
set Misc:Security:SecureBootModel to Disabled closes #3

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1165,7 +1165,7 @@
 			<key>ScanPolicy</key>
 			<integer>0</integer>
 			<key>SecureBootModel</key>
-			<string>Default</string>
+			<string>Disabled</string>
 			<key>Vault</key>
 			<string>Optional</string>
 			<key>AllowToggleSip</key>


### PR DESCRIPTION
This setting would not let me boot the installer.

I got the tip from here
https://www.reddit.com/r/hackintosh/comments/pl241p/oc_grabbed_zero_systemid_for_sb_this_is_not/

YMMV, I'm just following tips from a random person in Reddit.